### PR TITLE
use hardcoded sdkName and sdkVersion parameters (FF-962)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ test-data:
 
 .PHONY: test
 test: test-data
-	./vendor/phpunit/phpunit/phpunit tests/EppoClientTest.php
+	./vendor/phpunit/phpunit/phpunit tests

--- a/src/Config/SDKData.php
+++ b/src/Config/SDKData.php
@@ -14,8 +14,8 @@ class SDKData
 
     public function __construct()
     {
-        $this->sdkVersion = InstalledVersions::getRootPackage()['version'];
-        $this->sdkName = InstalledVersions::getRootPackage()['name'];
+        $this->sdkVersion = '1.2.1';
+        $this->sdkName = 'php-sdk';
     }
 
     /**

--- a/src/Config/SDKData.php
+++ b/src/Config/SDKData.php
@@ -2,28 +2,18 @@
 
 namespace Eppo\Config;
 
-use Composer\InstalledVersions;
-
 class SDKData
 {
-    /** @var string */
-    private $sdkVersion;
 
-    /** @var string */
-    private $sdkName;
-
-    public function __construct()
-    {
-        $this->sdkVersion = '1.2.1';
-        $this->sdkName = 'php-sdk';
-    }
+    const SDK_VERSION = '1.2.1';
+    const SDK_NAME = 'eppo-php-sdk';
 
     /**
      * @return string
      */
     public function getSdkVersion(): string
     {
-        return $this->sdkVersion;
+        return self::SDK_VERSION;;
     }
 
     /**
@@ -31,6 +21,6 @@ class SDKData
      */
     public function getSdkName(): string
     {
-        return $this->sdkName;
+        return self::SDK_NAME;
     }
 }

--- a/tests/SDKDataTest.php
+++ b/tests/SDKDataTest.php
@@ -16,6 +16,6 @@ final class SDKDataTest extends TestCase
     public function testGetSdkName()
     {
         $data = new SDKData();
-        $this->assertEquals('php-sdk', $data->getSdkName());
+        $this->assertEquals('eppo-php-sdk', $data->getSdkName());
     }
 }

--- a/tests/SDKDataTest.php
+++ b/tests/SDKDataTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Eppo\Tests;
+
+use Eppo\Config\SDKData;
+use PHPUnit\Framework\TestCase;
+
+final class SDKDataTest extends TestCase
+{
+    public function testGetVersion()
+    {
+        $data = new SDKData();
+        $this->assertEquals('1.2.1', $data->getSdkVersion());
+    }
+
+    public function testGetSdkName()
+    {
+        $data = new SDKData();
+        $this->assertEquals('php-sdk', $data->getSdkName());
+    }
+}


### PR DESCRIPTION
## context

we are tracking sdk name and version from the "root" package name; therefore our customer's application name is being reported in `sdkName` and their git branches in `sdkVersion`