### PR TITLE
Quality: Parameterize SDK and test-data branch for test workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: Eppo-exp/php-sdk
-        ref: ${SDK_BRANCH_NAME}
+        ref: ${{SDK_BRANCH_NAME}}
 
     - name: Echo input
       run: echo "Branch ${TEST_DATA_BRANCH_NAME}"
@@ -57,4 +57,4 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run tests
-      run: make test branchName=${TEST_DATA_BRANCH_NAME}
+      run: make test branchName=${{TEST_DATA_BRANCH_NAME}}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: eppo-exp/pho-sdk
-        branch: ${SDK_BRANCH_NAME}
+        ref: ${SDK_BRANCH_NAME}
 
     - name: Echo input
       run: echo "Branch ${TEST_DATA_BRANCH_NAME}"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,15 +31,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Echo input
+      run: |
+        echo "Branch ${TEST_DATA_BRANCH_NAME}"
+        echo "SDK Branch ${SDK_BRANCH_NAME}"
+
     - uses: actions/checkout@v3
       with:
         repository: Eppo-exp/php-sdk
         ref: ${{ github.event.inputs.sdk_branch || github.head_ref || github.ref_name || 'main' }}
 
-    - name: Echo input
-      run: |
-          echo "Branch ${TEST_DATA_BRANCH_NAME}"
-          echo "SDK Branch ${SDK_BRANCH_NAME}"
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,7 @@
 name: Run Tests
 
 env:
-  SDK_BRANCH_NAME: ${{ github.head_ref || github.ref_name || 'main' }}
+  SDK_BRANCH_NAME: ${{ github.event.inputs.sdk_branch  || github.head_ref || github.ref_name || 'main' }}
   TEST_DATA_BRANCH_NAME: ${{ github.event.inputs.test_data_branch || 'main' }}
 
 on:
@@ -37,8 +37,9 @@ jobs:
         ref: ${{ github.event.inputs.sdk_branch || github.head_ref || github.ref_name || 'main' }}
 
     - name: Echo input
-      run: echo "Branch ${TEST_DATA_BRANCH_NAME}"
-
+      run: |
+          echo "Branch ${TEST_DATA_BRANCH_NAME}"
+          echo "SDK Branch ${SDK_BRANCH_NAME}"
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,4 +68,4 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run tests
-      run: make test branchName=${{TEST_DATA_BRANCH_NAME}}
+      run: make test branchName=${{env.TEST_DATA_BRANCH_NAME}}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,8 +1,8 @@
 name: Run Tests
 
 env:
-  SDK_BRANCH_NAME: ${{ github.event.inputs.sdk_branch  || github.head_ref || github.ref_name || 'main' }}
-  TEST_DATA_BRANCH_NAME: ${{ github.event.inputs.test_data_branch || 'main' }}
+  SDK_BRANCH_NAME: ${{ inputs.sdk_branch  || github.head_ref || github.ref_name || 'main' }}
+  TEST_DATA_BRANCH_NAME: ${{ inputs.test_data_branch || 'main' }}
 
 on:
   push:
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: Eppo-exp/php-sdk
-        ref: ${{ github.event.inputs.sdk_branch || github.head_ref || github.ref_name || 'main' }}
+        ref: ${{ inputs.sdk_branch || github.head_ref || github.ref_name || 'main' }}
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
@@ -57,4 +57,4 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run tests
-      run: make test branchName=${{ github.event.inputs.test_data_branch || 'main' }}
+      run: make test branchName=${{ inputs.test_data_branch || 'main' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,12 +10,6 @@ on:
   pull_request:
     branches: [ "*" ]
   workflow_dispatch:
-    inputs:
-      test_data_branch:
-        type: string
-        description: The branch in sdk-test-data to target for testcase files
-        required: false
-        default: main
   workflow_call:
     inputs:
       test_data_branch:
@@ -23,6 +17,10 @@ on:
         description: The branch in sdk-test-data to target for testcase files
         required: false
         default: main
+      sdk_branch:
+        type: string
+        description: The branch of the SDK to test
+        required: false
 
 permissions:
   contents: read
@@ -36,7 +34,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: Eppo-exp/php-sdk
-        ref: ${{ github.head_ref || github.ref_name || 'main' }}
+        ref: ${{ github.event.inputs.sdk_branch || github.head_ref || github.ref_name || 'main' }}
 
     - name: Echo input
       run: echo "Branch ${TEST_DATA_BRANCH_NAME}"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,7 +50,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: Eppo-exp/php-sdk
-        ref: ${SDK_BRANCH_NAME}
+        ref: ${{ env.SDK_BRANCH_NAME}}
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
@@ -68,4 +68,4 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run tests
-      run: make test branchName=${TEST_DATA_BRANCH_NAME}
+      run: make test branchName=${{TEST_DATA_BRANCH_NAME}}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: Eppo-exp/php-sdk
-        ref: ${{ env.SDK_BRANCH_NAME}}
+        ref: ${{ github.head_ref || github.ref_name || 'main' }}
 
     - name: Echo input
       run: echo "Branch ${TEST_DATA_BRANCH_NAME}"
@@ -57,4 +57,4 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run tests
-      run: make test branchName=${{env.TEST_DATA_BRANCH_NAME}}
+      run: make test branchName=${{ github.event.inputs.test_data_branch || 'main' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     branches: [ "*" ]
   workflow_dispatch:
+    inputs:
+      test_data_branch:
+        type: string
+        description: The branch in sdk-test-data to target for testcase files
+        required: false
+        default: main
+      sdk_branch:
+        type: string
+        description: The branch of the SDK to test
+        required: false
   workflow_call:
     inputs:
       test_data_branch:
@@ -31,20 +41,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Output Inputs
+    - name: Echo
       run: |
-          echo "${{ toJSON(github.event.inputs) }}"
-          echo "${{ toJSON(github.event) }}"
-          echo "${{ toJSON(inputs) }}"
-    - name: Echo input
-      run: |
-        echo "Branch ${TEST_DATA_BRANCH_NAME}"
-        echo "SDK Branch ${SDK_BRANCH_NAME}"
+        echo "Running SDK Test using"
+        echo "Test Data: sdk-test-data@${TEST_DATA_BRANCH_NAME}"
+        echo "SDK Branch: php-sdk@${SDK_BRANCH_NAME}"
 
     - uses: actions/checkout@v3
       with:
         repository: Eppo-exp/php-sdk
-        ref: ${{ inputs.sdk_branch || github.head_ref || github.ref_name || 'main' }}
+        ref: ${SDK_BRANCH_NAME}
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
@@ -62,4 +68,4 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run tests
-      run: make test branchName=${{ inputs.test_data_branch || 'main' }}
+      run: make test branchName=${TEST_DATA_BRANCH_NAME}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,6 +31,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Output Inputs
+      run: |
+          echo "${{ toJSON(github.event.inputs) }}"
+          echo "${{ toJSON(github.event) }}"
+          echo "${{ toJSON(inputs) }}"
     - name: Echo input
       run: |
         echo "Branch ${TEST_DATA_BRANCH_NAME}"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        repository: eppo-exp/pho-sdk
+        repository: Eppo-exp/php-sdk
         ref: ${SDK_BRANCH_NAME}
 
     - name: Echo input

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,12 +1,28 @@
 name: Run Tests
 
+env:
+  SDK_BRANCH_NAME: ${{ github.head_ref || github.ref_name || 'main' }}
+  TEST_DATA_BRANCH_NAME: ${{ github.event.inputs.test_data_branch || 'main' }}
+
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "*" ]
   workflow_dispatch:
+    inputs:
+      test_data_branch:
+        type: string
+        description: The branch in sdk-test-data to target for testcase files
+        required: false
+        default: main
   workflow_call:
+    inputs:
+      test_data_branch:
+        type: string
+        description: The branch in sdk-test-data to target for testcase files
+        required: false
+        default: main
 
 permissions:
   contents: read
@@ -18,6 +34,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        repository: eppo-exp/pho-sdk
+        branch: ${SDK_BRANCH_NAME}
+
+    - name: Echo input
+      run: echo "Branch ${TEST_DATA_BRANCH_NAME}"
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
@@ -35,4 +57,4 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run tests
-      run: make test
+      run: make test branchName=${TEST_DATA_BRANCH_NAME}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: Eppo-exp/php-sdk
-        ref: ${{SDK_BRANCH_NAME}}
+        ref: ${{ env.SDK_BRANCH_NAME}}
 
     - name: Echo input
       run: echo "Branch ${TEST_DATA_BRANCH_NAME}"
@@ -57,4 +57,4 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run tests
-      run: make test branchName=${{TEST_DATA_BRANCH_NAME}}
+      run: make test branchName=${{env.TEST_DATA_BRANCH_NAME}}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,19 +7,11 @@ env:
 on:
   push:
     branches: [ "main" ]
+
   pull_request:
-    branches: [ "*" ]
+
   workflow_dispatch:
-    inputs:
-      test_data_branch:
-        type: string
-        description: The branch in sdk-test-data to target for testcase files
-        required: false
-        default: main
-      sdk_branch:
-        type: string
-        description: The branch of the SDK to test
-        required: false
+
   workflow_call:
     inputs:
       test_data_branch:
@@ -36,12 +28,12 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-and-test:
 
     runs-on: ubuntu-latest
 
     steps:
-    - name: Echo
+    - name: Display Testing Details
       run: |
         echo "Running SDK Test using"
         echo "Test Data: sdk-test-data@${TEST_DATA_BRANCH_NAME}"


### PR DESCRIPTION
🎟️ Fixes FF-3086 towards FF-3085

👯‍♂️ **Related PRs**
- [sdk-test-data#57](https://github.com/Eppo-exp/sdk-test-data/pull/57)
- [node-server-sdk#69](https://github.com/Eppo-exp/node-server-sdk/pull/69)
- [dot-net-server-sdk#44](https://github.com/Eppo-exp/dot-net-server-sdk/pull/44)


### Motivation
Changes are often made to the [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data) repository to capture new behaviours, bugs and edge cases. When these changes are pushed to `main`, the SDKs are cloned locally (locally to the github action running) and their respective tests are run. These tests are set up and run by copies of the SDK test workflows - see [sdk-test-data workflow](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows/test-sdks.yml). There are a number of limitations to this setup:

- Test steps are copied from the SDK’s respective workflows; changes to the SDK test workflows need to be replicated in sdk-test-data and this is not obvious to devs
- The SDK tests are not able to run against in-flight changes to `sdk-test-data`
- When new test-data is committed that breaks an SDK, that breakage is not surfaced in the SDK’s repository until some action triggers its testing workflow (on demand, on pull-request, etc.).

### Description of Changes
_This change_
🚀 - Each SDK's testing workflow is enhanced into a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows), exposing parameters for SDK branch and the sdk-test-data branch to use in testing.
- The test workflow runs using the main branch of sdk-test-data on all main pushes and Pull Requests using the PR's branch

_External to this Change_
[sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows) get two testing workflows.
1. ♻️  "Local Testing"- For all pull request changes, the "Local Testing" workflow calls the reusable SDK workflows, test results are recorded only in the sdk-test-data action. This is run using the main SDK branch and the "current" branch of workflow, i.e. the pull request branch. (SDK repo does not see/is not notified of test failures during PR lifecycle, only on push to main)
2. ♻️ 🧑‍💻 "Remote Testing" - On all pushes to the main branch of sdk-test-data, the SDK testing workflows are triggered to run within their respective repositories, alerting all subscribers of failed runs (repo is red/green).