### PR TITLE
Use ETAG when poller is polling

### DIFF
--- a/src/Config/ConfigurationLoader.php
+++ b/src/Config/ConfigurationLoader.php
@@ -67,8 +67,7 @@ class ConfigurationLoader implements IFlags, IBandits
     {
         $flagCacheAge = $this->getCacheAgeSeconds();
         if ($flagCacheAge === -1 || $flagCacheAge >= $this->cacheAgeLimit) {
-            $flagETag = $this->configurationStore->getMetadata(self::KEY_FLAG_ETAG);
-            $this->fetchAndStoreConfigurations($flagETag);
+            $this->reloadConfiguration();
         }
     }
 
@@ -178,5 +177,17 @@ class ConfigurationLoader implements IFlags, IBandits
         if (array_diff($references, $currentlyLoadedBanditModels)) {
             $this->fetchAndStoreBandits();
         }
+    }
+
+    /**
+     * @return void
+     * @throws HttpRequestException
+     * @throws InvalidApiKeyException
+     * @throws InvalidConfigurationException
+     */
+    public function reloadConfiguration(): void
+    {
+        $flagETag = $this->configurationStore->getMetadata(self::KEY_FLAG_ETAG);
+        $this->fetchAndStoreConfigurations($flagETag);
     }
 }

--- a/src/EppoClient.php
+++ b/src/EppoClient.php
@@ -119,7 +119,7 @@ class EppoClient
             self::POLL_INTERVAL_MILLIS,
             self::JITTER_MILLIS,
             function () use ($configLoader) {
-                $configLoader->fetchAndStoreConfigurations();
+                $configLoader->reloadConfiguration();
             }
         );
 


### PR DESCRIPTION
Eppo internal: fixes FF-3148

### Motivation and Context
The poller callback is using an outdated signature, throwing an exception when the poller is used (the php SDK reloads automatically if the data is older than 30sec).

### Description of changes
Extract method to pull last E_TAG and pass it to the config loader.