### PR TITLE
chore: move /api back to baseUrl

### DIFF
--- a/src/API/APIRequestWrapper.php
+++ b/src/API/APIRequestWrapper.php
@@ -20,9 +20,9 @@ use Webclient\Extension\Redirect\RedirectClientDecorator;
 class APIRequestWrapper
 {
     /** @var string */
-    private const UFC_ENDPOINT = '/api/flag-config/v1/config';
-    private const BANDIT_ENDPOINT = '/api/flag-config/v1/bandits';
-    private const CONFIG_BASE = 'https://fscdn.eppo.cloud';
+    private const UFC_ENDPOINT = '/flag-config/v1/config';
+    private const BANDIT_ENDPOINT = '/flag-config/v1/bandits';
+    private const CONFIG_BASE = 'https://fscdn.eppo.cloud/api';
 
     private string $baseUrl;
 


### PR DESCRIPTION
towards FF-3558

🎟️ [FF-3558](https://linear.app/eppo/issue/FF-3558/unify-sdk-request-baseurl) for context
