### PR TITLE
feat: Polling Config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 tests/data
 .phpunit.result.cache
+.vscode

--- a/src/Bandits/BanditReferenceIndexer.php
+++ b/src/Bandits/BanditReferenceIndexer.php
@@ -84,8 +84,8 @@ class BanditReferenceIndexer implements IBanditReferenceIndexer
             }
         }
 
-        // array_unique preserves array keys so duplicate entries that are dropped leave holes in the list of numeric keys
-        // `array_values` builds a new array from the values with reset numeric keys.
+        // array_unique preserves array keys so duplicate entries that are dropped leave holes in the list of numeric
+        // keys, then `array_values` builds a new array from the values with reset numeric keys.
         $this->activeBanditKeys = array_values(array_unique($banditKeys));
     }
 

--- a/src/EppoClient.php
+++ b/src/EppoClient.php
@@ -44,8 +44,6 @@ class EppoClient
     private RuleEvaluator $evaluator;
     private IBanditEvaluator $banditEvaluator;
 
-    private ?PollingOptions $pollingOptions = null;
-
     /**
      * @param ConfigurationLoader $configurationLoader
      * @param PollerInterface $poller
@@ -117,10 +115,12 @@ class EppoClient
             $baseUrl
         );
 
+        // Polling option defaults
         $cacheAgeLimit = self::DEFAULT_CACHE_AGE_LIMIT;
         $interval = self::DEFAULT_POLL_INTERVAL_MILLIS;
         $jitter = self::DEFAULT_JITTER_MILLIS;
 
+        // If polling options were passed, use them.
         if ($pollingOptions !== null) {
             if ($pollingOptions->cacheAgeLimitMillis !== null) {
                 $cacheAgeLimit = $pollingOptions->cacheAgeLimitMillis;
@@ -144,7 +144,6 @@ class EppoClient
         );
 
         self::$instance = self::createAndInitClient($configLoader, $poller, $assignmentLogger, $isGracefulMode);
-
 
         return self::$instance;
     }

--- a/src/PollingOptions.php
+++ b/src/PollingOptions.php
@@ -2,8 +2,26 @@
 
 namespace Eppo;
 
+/**
+ * Configuration options for the SDKs polling feature.
+ */
 abstract class PollingOptions
 {
+    /**
+     * @var int|null Age limit for cached configuration (when polling is not used).
+     */
+    public ?int $cacheAgeLimitMillis = null;
+
+    /**
+     * @var int|null Base interval used for polling for new configuration from the API serer.
+     *
+     * To use background polling, you must call
+     * <a href="https://docs.geteppo.com/sdks/server-sdks/php/initialization/#background-polling">startPolling</a>
+     */
     public ?int $pollingIntervalMillis;
+
+    /**
+     * @var int|null The maximum amount of random time to adjust each polling interval by.
+     */
     public ?int $pollingJitterMillis;
 }

--- a/src/PollingOptions.php
+++ b/src/PollingOptions.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Eppo;
+
+abstract class PollingOptions
+{
+    public ?int $pollingIntervalMillis;
+    public ?int $pollingJitterMillis;
+}

--- a/src/PollingOptions.php
+++ b/src/PollingOptions.php
@@ -25,7 +25,7 @@ final class PollingOptions
      */
     public readonly ?int $pollingJitterMillis;
 
-    public function __constructor(?int $cacheAgeLimitMillis, ?int $pollingIntervalMillis, ?int $pollingJitterMillis)
+    public function __construct(?int $cacheAgeLimitMillis, ?int $pollingIntervalMillis, ?int $pollingJitterMillis)
     {
         $this->cacheAgeLimitMillis = $cacheAgeLimitMillis;
         $this->pollingIntervalMillis = $pollingIntervalMillis;

--- a/src/PollingOptions.php
+++ b/src/PollingOptions.php
@@ -5,12 +5,12 @@ namespace Eppo;
 /**
  * Configuration options for the SDKs polling feature.
  */
-abstract class PollingOptions
+final class PollingOptions
 {
     /**
      * @var int|null Age limit for cached configuration (when polling is not used).
      */
-    public ?int $cacheAgeLimitMillis = null;
+    public readonly ?int $cacheAgeLimitMillis;
 
     /**
      * @var int|null Base interval used for polling for new configuration from the API serer.
@@ -18,10 +18,17 @@ abstract class PollingOptions
      * To use background polling, you must call
      * <a href="https://docs.geteppo.com/sdks/server-sdks/php/initialization/#background-polling">startPolling</a>
      */
-    public ?int $pollingIntervalMillis;
+    public readonly ?int $pollingIntervalMillis;
 
     /**
      * @var int|null The maximum amount of random time to adjust each polling interval by.
      */
-    public ?int $pollingJitterMillis;
+    public readonly ?int $pollingJitterMillis;
+
+    public function __constructor(?int $cacheAgeLimitMillis, ?int $pollingIntervalMillis, ?int $pollingJitterMillis)
+    {
+        $this->cacheAgeLimitMillis = $cacheAgeLimitMillis;
+        $this->pollingIntervalMillis = $pollingIntervalMillis;
+        $this->pollingJitterMillis = $pollingJitterMillis;
+    }
 }

--- a/tests/Config/ConfigurationLoaderTest.php
+++ b/tests/Config/ConfigurationLoaderTest.php
@@ -254,7 +254,7 @@ class ConfigurationLoaderTest extends TestCase
 
         $cache = DefaultCacheFactory::create();
         // Act: Create a new FCL with a 0sec ttl and retrieve a flag
-        $loader = new ConfigurationLoader($apiWrapper, new ConfigurationStore($cache), cacheAgeLimit: 0);
+        $loader = new ConfigurationLoader($apiWrapper, new ConfigurationStore($cache), cacheAgeLimitMillis: 0);
 
         // Mocks verify interaction of loader <--> API requests and loader <--> config store
         $apiWrapper->expects($this->exactly(2))

--- a/tests/EppoClientTest.php
+++ b/tests/EppoClientTest.php
@@ -302,11 +302,11 @@ class EppoClientTest extends TestCase
     {
         $apiKey = 'dummy-api-key';
 
-        $pollingOptions = new class extends PollingOptions {
-            public ?int $pollingIntervalMillis = 10000;
-            public ?int $pollingJitterMillis = 2000;
-            public ?int $cacheAgeLimitMillis = 5;
-        };
+        $pollingOptions = new PollingOptions(
+            pollingIntervalMillis: 10000,
+            pollingJitterMillis: 2000,
+            cacheAgeLimitMillis: 5
+        );
 
         $client = EppoClient::init(
             $apiKey,

--- a/tests/EppoClientTest.php
+++ b/tests/EppoClientTest.php
@@ -298,14 +298,18 @@ class EppoClientTest extends TestCase
         return $tests;
     }
 
+    /**
+     * @throws EppoClientInitializationException
+     * @throws EppoClientException
+     */
     public function testInitWithPollingOptions(): void
     {
         $apiKey = 'dummy-api-key';
 
         $pollingOptions = new PollingOptions(
+            cacheAgeLimitMillis: 5,
             pollingIntervalMillis: 10000,
-            pollingJitterMillis: 2000,
-            cacheAgeLimitMillis: 5
+            pollingJitterMillis: 2000
         );
 
         $client = EppoClient::init(

--- a/tests/WebServer/MockWebServer.php
+++ b/tests/WebServer/MockWebServer.php
@@ -20,7 +20,6 @@ class MockWebServer
     ) {
         $this->serverAddress = "localhost:$port";
         $this->serveFile($ufcFile);
-        usleep(500000);
     }
 
     /**
@@ -41,7 +40,6 @@ class MockWebServer
     {
         $this->stop();
         $this->serveFile($ufcFile);
-        usleep(500000);
         return $this;
     }
 
@@ -79,5 +77,7 @@ class MockWebServer
         if (!is_resource($this->process)) {
             throw new Exception('Unable to start PHP built-in web server.');
         }
+
+        usleep(500000);
     }
 }

--- a/tests/WebServer/MockWebServer.php
+++ b/tests/WebServer/MockWebServer.php
@@ -68,7 +68,6 @@ class MockWebServer
      */
     private function serveFile(string $ufcFile): void
     {
-        print("serving file\n");
         $descriptorSpec = [
             0 => ["pipe", "r"], // stdin
             1 => ["pipe", "w"], // stdout
@@ -76,8 +75,6 @@ class MockWebServer
         ];
 
         $cmd = "UFC=$ufcFile php -S $this->serverAddress " . __DIR__ . '/router.php';
-        print($cmd . "\n");
-
         $this->process = proc_open($cmd, $descriptorSpec, $pipes);
         if (!is_resource($this->process)) {
             throw new Exception('Unable to start PHP built-in web server.');


### PR DESCRIPTION
fixes FF-4095

## Motivation and Context
PHP uses hard-coded parameters to control polling and cache freshness (PHP reloads if the cache is too old). This limitation leaves PHP behind other SDKs and can make debugging customer issues harder

## Chanages
- Testing infrastructure changes to allow for changing the file served
- Lint
- Deal with the cache age in milliseconds, not seconds
- final `PollingOptions` class that approximates the ease of Typescript's Type
- Use the newly exposed polling option.s