### PR TITLE
fix: set cache timestamp only when changes are made

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 [//]: # (Describe your changes in detail)
 
 ## How has this been documented?
-[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explan why no documentation changes are required)
+[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)
 
 ## How has this been tested?
 [//]: # (Please describe in detail how you tested your changes)

--- a/src/Cache/DefaultCacheFactory.php
+++ b/src/Cache/DefaultCacheFactory.php
@@ -9,9 +9,6 @@ use Symfony\Component\Cache\Psr16Cache;
 
 class DefaultCacheFactory
 {
-    /**
-     * @throws Exception
-     */
     public static function create(): CacheInterface
     {
         $psr6Cache = new FilesystemAdapter(

--- a/src/Config/ConfigurationLoader.php
+++ b/src/Config/ConfigurationLoader.php
@@ -109,11 +109,11 @@ class ConfigurationLoader implements IFlags, IBandits
             if ($indexer->hasBandits()) {
                 $this->fetchBanditsAsRequired($indexer);
             }
-        }
 
-        // Store metadata for next time.
-        $this->configurationStore->setMetadata(self::KEY_FLAG_TIMESTAMP, $this->millitime());
-        $this->configurationStore->setMetadata(self::KEY_FLAG_ETAG, $response->ETag);
+            // Store metadata for next time.
+            $this->configurationStore->setMetadata(self::KEY_FLAG_TIMESTAMP, $this->millitime());
+            $this->configurationStore->setMetadata(self::KEY_FLAG_ETAG, $response->ETag);
+        }
     }
 
     private function getCacheAgeInMillis(): int

--- a/src/EppoClient.php
+++ b/src/EppoClient.php
@@ -644,7 +644,8 @@ class EppoClient
         PollerInterface $poller,
         ?LoggerInterface $logger = null,
         ?bool $isGracefulMode = false,
-        ?IBanditEvaluator $banditEvaluator = null
+        ?IBanditEvaluator $banditEvaluator = null,
+        ?bool $throwOnFailedInit = true,
     ): EppoClient {
         return self::createAndInitClient(
             $configurationLoader,
@@ -652,7 +653,7 @@ class EppoClient
             $logger,
             $isGracefulMode,
             $banditEvaluator,
-            throwOnFailedInit: true
+            throwOnFailedInit: $throwOnFailedInit
         );
     }
 }

--- a/src/EppoClient.php
+++ b/src/EppoClient.php
@@ -84,6 +84,7 @@ class EppoClient
         RequestFactoryInterface $requestFactory = null,
         ?bool $isGracefulMode = true,
         ?PollingOptions $pollingOptions = null,
+        ?bool $throwOnFailedInit = false,
     ): EppoClient {
         // Get SDK metadata to pass as params in the http client.
         $sdkData = new SDKData();
@@ -93,11 +94,7 @@ class EppoClient
         ];
 
         if (!$cache) {
-            try {
-                $cache = (new DefaultCacheFactory())->create();
-            } catch (Exception $e) {
-                throw EppoClientInitializationException::from($e);
-            }
+            $cache = (new DefaultCacheFactory())->create();
         }
 
         $configStore = new ConfigurationStore($cache);
@@ -143,27 +140,33 @@ class EppoClient
             }
         );
 
-        self::$instance = self::createAndInitClient($configLoader, $poller, $assignmentLogger, $isGracefulMode);
+        self::$instance = self::createAndInitClient($configLoader, $poller, $assignmentLogger, $isGracefulMode, throwOnFailedInit: $throwOnFailedInit);
 
         return self::$instance;
     }
 
     /**
-     * @throws EppoClientInitializationException
+     * @throws EppoClientInitializationException|InvalidConfigurationException
      */
     private static function createAndInitClient(
         ConfigurationLoader $configLoader,
         PollerInterface $poller,
         ?LoggerInterface $assignmentLogger,
         ?bool $isGracefulMode,
-        ?IBanditEvaluator $banditEvaluator = null
+        ?IBanditEvaluator $banditEvaluator = null,
+        ?bool $throwOnFailedInit = false,
     ): EppoClient {
         try {
             $configLoader->reloadConfigurationIfExpired();
         } catch (HttpRequestException | InvalidApiKeyException $e) {
-            throw new EppoClientInitializationException(
-                'Unable to initialize Eppo Client: ' . $e->getMessage()
-            );
+            $message = 'Unable to initialize Eppo Client: ' . $e->getMessage();
+            if ($throwOnFailedInit) {
+                throw new EppoClientInitializationException(
+                    $message
+                );
+            } else {
+                syslog(LOG_INFO, "[Eppo SDK] " . $message);
+            }
         }
         return new self($configLoader, $poller, $assignmentLogger, $isGracefulMode, $banditEvaluator);
     }
@@ -643,6 +646,13 @@ class EppoClient
         ?bool $isGracefulMode = false,
         ?IBanditEvaluator $banditEvaluator = null
     ): EppoClient {
-        return self::createAndInitClient($configurationLoader, $poller, $logger, $isGracefulMode, $banditEvaluator);
+        return self::createAndInitClient(
+            $configurationLoader,
+            $poller,
+            $logger,
+            $isGracefulMode,
+            $banditEvaluator,
+            throwOnFailedInit: true
+        );
     }
 }

--- a/tests/Config/ConfigurationLoaderTest.php
+++ b/tests/Config/ConfigurationLoaderTest.php
@@ -120,8 +120,6 @@ class ConfigurationLoaderTest extends TestCase
             ['', [], new Psr18Client(), new Psr17Factory()]
         )->getMock();
 
-        // Mocks verify interaction of loader <--> API requests and loader <--> config store
-
         $apiWrapper->expects($this->exactly(2))
             ->method('getUFC')
             ->willReturnCallback(

--- a/tests/Config/ConfigurationLoaderTest.php
+++ b/tests/Config/ConfigurationLoaderTest.php
@@ -99,22 +99,7 @@ class ConfigurationLoaderTest extends TestCase
             true,
             "ETAG"
         );
-        $banditsRaw = '{
-            "bandits": {
-                "cold_start_bandit": {
-                    "banditKey": "cold_start_bandit",
-                    "modelName": "falcon",
-                    "updatedAt": "2023-09-13T04:52:06.462Z",
-                    "modelVersion": "cold start",
-                    "modelData": {
-                        "gamma": 1.0,
-                        "defaultActionScore": 0.0,
-                        "actionProbabilityFloor": 0.0,
-                        "coefficients": {}
-                    }
-                }
-            }
-        }';
+        $banditsRaw = '{"bandits": {}}';
 
         $apiWrapper = $this->getMockBuilder(APIRequestWrapper::class)->setConstructorArgs(
             ['', [], new Psr18Client(), new Psr17Factory()]
@@ -124,6 +109,7 @@ class ConfigurationLoaderTest extends TestCase
             ->method('getUFC')
             ->willReturnCallback(
                 function (?string $eTag) use ($flagsResourceResponse, $flagsRaw) {
+                    // Return not modified if the etag sent is not null.
                     return $eTag == null ? $flagsResourceResponse : new APIResource(
                         $flagsRaw,
                         false,
@@ -150,6 +136,8 @@ class ConfigurationLoaderTest extends TestCase
         $loader->fetchAndStoreConfigurations("ETAG");
 
         $this->assertEquals("ETAG", $configStore->getMetadata("flagETag"));
+
+        // The timestamp should not have changed; the config did not change, so the timestamp should not be updated.
         $this->assertEquals($timestamp1, $configStore->getMetadata("flagTimestamp"));
     }
 

--- a/tests/Config/ConfigurationLoaderTest.php
+++ b/tests/Config/ConfigurationLoaderTest.php
@@ -69,7 +69,7 @@ class ConfigurationLoaderTest extends TestCase
 
         $configStore = new ConfigurationStore(DefaultCacheFactory::create());
 
-        $loader = new ConfigurationLoader($apiWrapper, $configStore, 25);
+        $loader = new ConfigurationLoader($apiWrapper, $configStore);
         $loader->fetchAndStoreConfigurations(null);
 
 
@@ -99,8 +99,6 @@ class ConfigurationLoaderTest extends TestCase
             true,
             "ETAG"
         );
-        $flagsJson = json_decode($flagsRaw, true);
-        $flags = array_map(fn($flag) => (new UFCParser())->parseFlag($flag), $flagsJson['flags']);
         $banditsRaw = '{
             "bandits": {
                 "cold_start_bandit": {
@@ -142,7 +140,7 @@ class ConfigurationLoaderTest extends TestCase
 
         $configStore = new ConfigurationStore(DefaultCacheFactory::create());
 
-        $loader = new ConfigurationLoader($apiWrapper, $configStore, 25);
+        $loader = new ConfigurationLoader($apiWrapper, $configStore);
         $loader->fetchAndStoreConfigurations(null);
 
         $timestamp1 = $configStore->getMetadata("flagTimestamp");

--- a/tests/EppoClientTest.php
+++ b/tests/EppoClientTest.php
@@ -179,7 +179,12 @@ class EppoClientTest extends TestCase
     public function testRepoTestCases(): void
     {
         try {
-            $client = EppoClient::init('dummy', self::$mockServer->serverAddress, isGracefulMode: false);
+            $client = EppoClient::init(
+                'dummy',
+                self::$mockServer->serverAddress,
+                isGracefulMode: false,
+                throwOnFailedInit: true
+            );
         } catch (Exception $exception) {
             self::fail('Failed to initialize EppoClient: ' . $exception->getMessage());
         }
@@ -315,7 +320,9 @@ class EppoClientTest extends TestCase
         );
 
         $response = new Response(stream: Utils::streamFor(file_get_contents(__DIR__ . '/data/ufc/flags-v1.json')));
-        $secondResponse = new Response(stream: Utils::streamFor(file_get_contents(__DIR__ . '/data/ufc/bandit-flags-v1.json')));
+        $secondResponse = new Response(stream: Utils::streamFor(
+            file_get_contents(__DIR__ . '/data/ufc/bandit-flags-v1.json')
+        ));
 
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->expects($this->atLeast(2))
@@ -327,7 +334,8 @@ class EppoClientTest extends TestCase
             "fake address",
             httpClient: $httpClient,
             isGracefulMode: false,
-            pollingOptions: $pollingOptions
+            pollingOptions: $pollingOptions,
+            throwOnFailedInit: true
         );
 
         $this->assertEquals(
@@ -335,7 +343,7 @@ class EppoClientTest extends TestCase
             $client->getNumericAssignment(self::EXPERIMENT_NAME, 'subject-10', [], 0)
         );
         // Wait a little bit for the cache to age out and the mock server to spin up.
-        usleep(75*1000);
+        usleep(75 * 1000);
 
         $this->assertEquals(
             0,


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes FF-4278 and FF-3947

## Motivation and Context
Updating the cache timestamp when it hasn't change causes issues when invalidating the cache based solely on time (and not on the eTag).
While we're here, we want to default the [SDKs to squash exceptions during initialization](https://linear.app/eppo/issue/FF-3943/[parent]-change-sdk-default-error-handling-on-init-to-squash)

## Description
- Set the timestamp only if there are changes
- Additional init parameter to suppress exceptions on init
- cleaned up superfluous exception throwing.

## How has this been documented?
[linear](https://linear.app/eppo/issue/FF-4279/[docs]-update-php-docs-with-throwonfailedinit-param)

## How has this been tested?
- unit tests
