### PR TITLE
feat: publish SDK workflow with package testing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,58 @@
+name: Publish Release
+
+on:
+  push:
+    branches: [ tp/* ]
+#  release:
+#    types: [created]
+
+jobs:
+  # unit tests
+
+  # package test
+  test:
+    runs-on: ${{ matrix.platform == 'linux' && 'ubuntu-latest' || matrix.platform == 'macos' && 'macos-13' || matrix.platform == 'windows' && 'windows-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ 'linux' ]
+
+    steps:
+      - name: Display Testing Details
+        run: |
+          echo "Running SDK Test before publishing release"
+          echo "Release tag: ${{ github.ref_name }}"
+
+      - uses: Eppo-exp/sdk-test-data/.github/actions/test-server-package@main
+        with:
+          platform: ${{ matrix.platform }}
+          sdk_name: 'eppo/php-sdk'
+          sdk_ref: ${{ github.ref_name }}
+          sdk_relay_dir: 'php-sdk-relay'
+          service_account_key: ${{ secrets.SERVICE_ACCOUNT_KEY }}
+          sdk_testing_project_id: ${{ vars.SDK_TESTING_PROJECT_ID }}
+          sdk_testing_region: ${{ vars.SDK_TESTING_REGION }}
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event.release.draft
+
+    steps:
+      - name: Update release (dry run)
+        #        uses: actions/github-script@v6
+        #        with:
+        #          script: |
+        #            github.rest.repos.updateRelease({
+        #              owner: context.repo.owner,
+        #              repo: context.repo.repo,
+        #              release_id: context.payload.release.id,
+        #              draft: false
+        #            });
+        run: |
+          echo "github.rest.repos.updateRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            release_id: context.payload.release.id,
+            draft: false
+          });"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,11 +9,7 @@ jobs:
 
   # package test
   test:
-    runs-on: ${{ matrix.platform == 'linux' && 'ubuntu-latest' || matrix.platform == 'macos' && 'macos-13' || matrix.platform == 'windows' && 'windows-latest' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ 'linux' ]
+    runs-on: 'ubuntu-latest'
 
     steps:
       - name: Display Testing Details
@@ -23,7 +19,7 @@ jobs:
 
       - uses: Eppo-exp/sdk-test-data/.github/actions/test-server-package@main
         with:
-          platform: ${{ matrix.platform }}
+          platform: 'linux'
           sdk_name: 'eppo/php-sdk'
           sdk_ref: ${{ github.ref_name }}
           sdk_relay_dir: 'php-sdk-relay'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,10 +1,8 @@
 name: Publish Release
 
 on:
-  push:
-    branches: [ tp/* ]
-#  release:
-#    types: [created]
+  release:
+    types: [ published ]
 
 jobs:
   # unit tests
@@ -36,23 +34,13 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
-    if: github.event.release.draft
 
     steps:
       - name: Update release (dry run)
-        #        uses: actions/github-script@v6
-        #        with:
-        #          script: |
-        #            github.rest.repos.updateRelease({
-        #              owner: context.repo.owner,
-        #              repo: context.repo.repo,
-        #              release_id: context.payload.release.id,
-        #              draft: false
-        #            });
         run: |
-          echo "github.rest.repos.updateRelease({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            release_id: context.payload.release.id,
-            draft: false
-          });"
+          echo "github.rest.git.createRef({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      ref: 'refs/tags/${{github.event.release.release_id}}',
+                      sha: context.sha
+                    })"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Releases
+
+When creating a release, **do not apply a tag**. Name the release as normal and publish it. The
+workflow `.github/workflows/publish-release.yml`
+will run tests and then apply a tag matching the release name. This tag will be picked up automatically by Packagist
+which will then publish a new release.


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes FF-4321
:scroll: Design Doc: __link if applicable__

## Motivation and Context
Packagist automatically publishes versions when the repo is tagged. This workflow runs tests and if successful, applies a tag to the repository matching the release name.

